### PR TITLE
Make *_hex return an empty string on NULL-only sequence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlite-hashes"
-version = "0.4.0"  # This value is also used in the README.md
+version = "0.5.0"  # This value is also used in the README.md
 description = "Hashing functions for SQLite with aggregation support: MD5, SHA1, SHA256, SHA512"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-hashes"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This crate uses [rusqlite](https://crates.io/crates/rusqlite) to add user-define
 
 ### Scalar functions
 
-There are two types of scalar functions, e.g. `sha256(...)` and `sha256_hex(...)`. The first one returns a blob, and the second one returns a hex string.  All functions can hash text and blob values, but will raise an error on other types. Functions support any number of arguments, e.g. `sha256(a, b, c, ...)`, hashing them in order. All `NULL` values will be ignored. If all function parameters are `NULL`, the result is `NULL`. You may include an empty string param to always get a non-NULL value, e.g. `sha256(a, b, c, '')`.
+There are two types of scalar functions, the `<hash>(...)` and `<hash>_hex(...)`, e.g. `sha256(...)` and `sha256_hex(...)`. The first one returns a blob, and the second one returns a hex string.  All functions can hash text and blob values, but will raise an error on other types. Functions support any number of arguments, e.g. `sha256(a, b, c, ...)`, hashing them in order. All `NULL` values are ignored. When calling the built-in SQLite `hex(NULL)`, the result is an empty string, so `sha256_hex(NULL)` will return an empty string as well to be consistent.
 
 ```rust
 use sqlite_hashes::{register_hash_functions, rusqlite::Connection};
@@ -108,7 +108,7 @@ By default, this crate will compile with all features. You can enable just the o
 
 ```toml
 [dependencies]
-sqlite-hashes = { version = "0.4", default-features = false, features = ["hex", "window", "sha256"] }
+sqlite-hashes = { version = "0.5", default-features = false, features = ["hex", "window", "sha256"] }
 ``` 
 
 ## Development

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ pub use rusqlite;
 
 use crate::rusqlite::{Connection, Result};
 
-#[cfg(feature = "aggregate")]
 mod aggregate;
 mod scalar;
+mod state;
 
 #[cfg(feature = "md5")]
 mod md5;

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,71 @@
+use digest::Digest;
+#[cfg(feature = "hex")]
+use hex::ToHex as _;
+
+#[derive(Debug, Default)]
+pub enum HashState<T> {
+    #[default]
+    Created,
+    Started,
+    HasValues(T),
+}
+
+impl<T: Digest + Clone> HashState<T> {
+    #[inline]
+    pub fn add_null(&mut self) {
+        if let Self::Created = self {
+            *self = Self::Started;
+        }
+    }
+
+    #[inline]
+    pub fn add_value(&mut self, value: &[u8]) {
+        match self {
+            Self::Created | Self::Started => {
+                let mut hasher = T::new();
+                hasher.update(value);
+                *self = Self::HasValues(hasher);
+            }
+            Self::HasValues(hasher) => {
+                hasher.update(value);
+            }
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "window")]
+    pub fn calc(&self) -> Option<Vec<u8>> {
+        match self {
+            Self::Created | Self::Started => None,
+            Self::HasValues(hasher) => Some(hasher.clone().finalize().to_vec()),
+        }
+    }
+
+    #[inline]
+    #[cfg(all(feature = "window", feature = "hex"))]
+    pub fn calc_hex(&self) -> Option<String> {
+        match self {
+            Self::Created => None,
+            Self::Started => Some(String::new()),
+            Self::HasValues(hasher) => Some(hasher.clone().finalize().to_vec().encode_hex_upper()),
+        }
+    }
+
+    #[inline]
+    pub fn finalize(self) -> Option<Vec<u8>> {
+        match self {
+            Self::Created | Self::Started => None,
+            Self::HasValues(hasher) => Some(hasher.clone().finalize().to_vec()),
+        }
+    }
+
+    #[inline]
+    #[cfg(feature = "hex")]
+    pub fn finalize_hex(self) -> Option<String> {
+        match self {
+            Self::Created => None,
+            Self::Started => Some(String::new()),
+            Self::HasValues(hasher) => Some(hasher.finalize().to_vec().encode_hex_upper()),
+        }
+    }
+}

--- a/tests/aggregate.rs
+++ b/tests/aggregate.rs
@@ -43,8 +43,8 @@ fn simple_concat() {
 #[cfg(feature = "hex")]
 fn simple_concat_hex() {
     let c = Conn::new();
-    test_all!(c.select("_concat_hex(NULL)"), NULL);
-    test_all!(c.select("_concat_hex(NULL, NULL, NULL)"), NULL);
+    test_all!(c.select("_concat_hex(NULL)"), EMPTY);
+    test_all!(c.select("_concat_hex(NULL, NULL, NULL)"), EMPTY);
     test_all!(c.select("_concat_hex(1)"), ERROR);
     test_all!(c.select("_concat_hex(0.42)"), ERROR);
     test_all!(c.select("_concat_hex()"), ERROR);
@@ -70,14 +70,17 @@ fn simple_concat_hex() {
 #[test]
 fn hash_concat() {
     let c = Conn::new();
-    test_all!(c.legacy_aggregate(*_concat), blob("aaabbbccc"));
+    test_all!(c.legacy_text_aggregate(*_concat), blob("aaabbbccc"));
+    test_all!(c.legacy_blob_aggregate(*_concat), blob("aaabbbccc"));
+    test_all!(c.legacy_null_text_aggregate(*_concat), NULL);
+    test_all!(c.legacy_null_blob_aggregate(*_concat), NULL);
 }
 
 #[test]
 #[cfg(feature = "hex")]
 fn hash_concat_hex() {
     let c = Conn::new();
-    test_all!(c.legacy_aggregate(*_concat_hex), hex("aaabbbccc"));
+    test_all!(c.legacy_text_aggregate(*_concat_hex), hex("aaabbbccc"));
 }
 
 #[test]
@@ -118,6 +121,9 @@ fn concat_sequence_hex() {
 
     test_all!(c.seq_0("_concat_hex(cast(v as text))"), NULL);
     test_all!(c.seq_0("_concat_hex(cast(v as blob))"), NULL);
+
+    test_all!(c.seq_1("_concat_hex(cast(NULL as text))"), EMPTY);
+    test_all!(c.seq_1("_concat_hex(cast(NULL as blob))"), EMPTY);
 
     test_all!(c.seq_1("_concat_hex(cast(v as text))"), hex("1"));
     test_all!(c.seq_1("_concat_hex(cast(v as blob))"), hex("1"));

--- a/tests/scalar.rs
+++ b/tests/scalar.rs
@@ -41,8 +41,8 @@ fn simple() {
 #[cfg(feature = "hex")]
 fn simple_hex() {
     let c = Conn::new();
-    test_all!(c.select("_hex(NULL)"), NULL);
-    test_all!(c.select("_hex(NULL, NULL, NULL)"), NULL);
+    test_all!(c.select("_hex(NULL)"), EMPTY);
+    test_all!(c.select("_hex(NULL, NULL, NULL)"), EMPTY);
     test_all!(c.select("_hex(1)"), ERROR);
     test_all!(c.select("_hex(0.42)"), ERROR);
     test_all!(c.select("_hex()"), ERROR);

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -14,14 +14,15 @@ fn init() {
 fn window() {
     let c = Conn::new();
 
-    test_all!(c.window_one(*_concat), blob("aaabbbccc"));
-
+    test_all!(c.window_text_one(*_concat), blob("aaabbbccc"));
     test_all!(
-        c.growing_seq(*_concat),
+        c.growing_text_seq(*_concat),
         blob[vec!["aaa", "aaabbb", "aaabbbccc"]]
     );
 
     test_all!(c.window_err(*_concat), ERROR);
+
+    test_all!(c.window_text_zero(*_concat), NO_ROWS);
 }
 
 #[test]
@@ -29,10 +30,12 @@ fn window() {
 fn window_hex() {
     let c = Conn::new();
 
-    test_all!(c.window_one(*_concat_hex), hex("aaabbbccc"));
+    test_all!(c.window_text_one(*_concat_hex), hex("aaabbbccc"));
 
     test_all!(
-        c.growing_seq(*_concat_hex),
+        c.growing_text_seq(*_concat_hex),
         hex[vec!["aaa", "aaabbb", "aaabbbccc"]]
     );
+
+    test_all!(c.window_text_zero(*_concat_hex), NO_ROWS);
 }


### PR DESCRIPTION
The built-in `hex(NULL)` always returns an empty string, so it would be better to follow that convention