### PR TITLE
chore: release v0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/nyurik/sqlite-hashes/compare/v0.10.3...v0.10.4) - 2025-06-07
+
+### Other
+
+- use CI RELEASE_PLZ_TOKEN to release bins
+
 ## [0.10.3](https://github.com/nyurik/sqlite-hashes/compare/v0.10.2...v0.10.3) - 2025-06-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "sqlite-hashes"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "blake3",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-hashes"
 # !!! This value is also used in the README.md
-version = "0.10.3"
+version = "0.10.4"
 description = "Hashing functions for SQLite with aggregation support: MD5, SHA1, SHA256, SHA512, Blake3, FNV-1a, xxHash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-hashes"


### PR DESCRIPTION



## 🤖 New release

* `sqlite-hashes`: 0.10.3 -> 0.10.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.4](https://github.com/nyurik/sqlite-hashes/compare/v0.10.3...v0.10.4) - 2025-06-07

### Other

- use CI RELEASE_PLZ_TOKEN to release bins
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).