### PR TITLE
chore: release v0.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.5](https://github.com/nyurik/sqlite-hashes/compare/v0.10.4...v0.10.5) - 2025-06-08
+
+### Added
+
+- consolidate release CI, dedup release and PR
+
+### Other
+
+- update dependencies
+
 ## [0.10.4](https://github.com/nyurik/sqlite-hashes/compare/v0.10.3...v0.10.4) - 2025-06-07
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "foldhash",
 ]
@@ -563,9 +563,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "noncrypto-digests"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5004d386703d5fb6483ff1201ac32ec12f52d5c8563c0bcac875d098a79a93e1"
+checksum = "cd78bcdcd11c3c76b02d89102fa435306111fd22b40076442fc0bffe803eaf4a"
 dependencies = [
  "digest",
  "fnv",
@@ -635,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -828,9 +828,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-hashes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "sqlite-hashes"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "blake3",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-hashes"
 # !!! This value is also used in the README.md
-version = "0.10.4"
+version = "0.10.5"
 description = "Hashing functions for SQLite with aggregation support: MD5, SHA1, SHA256, SHA512, Blake3, FNV-1a, xxHash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-hashes"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,4 @@
 [workspace]
 git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"
+dependencies_update = true


### PR DESCRIPTION



## 🤖 New release

* `sqlite-hashes`: 0.10.4 -> 0.10.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.5](https://github.com/nyurik/sqlite-hashes/compare/v0.10.4...v0.10.5) - 2025-06-08

### Added

- consolidate release CI, dedup release and PR

### Other

- update dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).