### PR TITLE
chore: release v0.10.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.10](https://github.com/nyurik/sqlite-hashes/compare/v0.10.9...v0.10.10) - 2026-06-23
+
+### Other
+
+- update lock to latest
+- update .gitignore
+- format justfile
+- *(deps)* bump log from 0.4.32 to 0.4.33 in the all-cargo-version-updates group ([#132](https://github.com/nyurik/sqlite-hashes/pull/132))
+- *(deps)* bump the all-actions-version-updates group with 3 updates ([#133](https://github.com/nyurik/sqlite-hashes/pull/133))
+- justfile cleanup
+- clippy settings
+
 ## [0.10.9](https://github.com/nyurik/sqlite-hashes/compare/v0.10.8...v0.10.9) - 2026-06-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1041,7 +1041,7 @@ checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "sqlite-hashes"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "blake3",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqlite-hashes"
 # This value is also used in the README.md
-version = "0.10.9"
+version = "0.10.10"
 description = "Hashing functions for SQLite with aggregation support: MD5, SHA1, SHA256, SHA512, Blake3, FNV-1a, xxHash"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/sqlite-hashes"


### PR DESCRIPTION



## 🤖 New release

* `sqlite-hashes`: 0.10.9 -> 0.10.10 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.10](https://github.com/nyurik/sqlite-hashes/compare/v0.10.9...v0.10.10) - 2026-06-23

### Other

- update lock to latest
- update .gitignore
- format justfile
- *(deps)* bump log from 0.4.32 to 0.4.33 in the all-cargo-version-updates group ([#132](https://github.com/nyurik/sqlite-hashes/pull/132))
- *(deps)* bump the all-actions-version-updates group with 3 updates ([#133](https://github.com/nyurik/sqlite-hashes/pull/133))
- justfile cleanup
- clippy settings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).